### PR TITLE
Update blink.css - use more specific CSS selectors

### DIFF
--- a/src/main/webapp/css/blink.css
+++ b/src/main/webapp/css/blink.css
@@ -21,6 +21,6 @@
   animation:         deploying 2s infinite; /* IE 10+ */
 }
 
-#side-panel { display: none; }
+#page-body #side-panel { display: none; }
 
-#main-panel { width: 100%; margin-left: 0px; }
+#page-body #main-panel { width: 100%; margin-left: 0px; }


### PR DESCRIPTION
Change prevent these styles from being overridden by layout-common.css